### PR TITLE
Revice for workday

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -5,6 +5,5 @@ github:
     - osdakira
   # org: osdakira
   # team_slug:
-number_of_minutes_dating_back: 120
 reminder_stop_key: '[ok]'
 reminder_message_template: '%<mention_to>s from github-auto-reminder'

--- a/config.yml
+++ b/config.yml
@@ -6,4 +6,4 @@ github:
   # org: osdakira
   # team_slug:
 reminder_stop_key: '[ok]'
-reminder_message_template: '%<mention_to>s from github-auto-reminder'
+reminder_message_template: '%<mention_to>s from github-auto-reminder. You should reply with mention or write comment with %<reminder_stop_key>s'

--- a/main.rb
+++ b/main.rb
@@ -129,7 +129,11 @@ def notify(unreplied_comment_rows)
 end
 
 def make_reminder_message(mention_to)
-  format(config['reminder_message_template'], mention_to: mention_to)
+  format(
+    config['reminder_message_template'],
+    mention_to: mention_to,
+    reminder_stop_key: reminder_stop_key.sub('[', '&#91;').sub(']', '&#93;'),
+  )
 end
 
 def db

--- a/main.rb
+++ b/main.rb
@@ -132,6 +132,11 @@ end
 
 def db
   db = SQLite3::Database.new('./issues_comments.sqlite3')
+  create_table_issues_comments(db)
+  db
+end
+
+def create_table_issues_comments(db)
   create_sql = <<-"SQL"
     CREATE TABLE IF NOT EXISTS issues_comments (
       id integer primary key autoincrement,
@@ -140,7 +145,6 @@ def db
     );
   SQL
   db.execute(create_sql)
-  db
 end
 
 def columns


### PR DESCRIPTION
業務時間外や、週末は通知してほしくない。
よって、github から取得する時刻を、固定の時刻ではなく、最後に取得した時刻に変更。
暴走する危険があるが、確認しながらやれば良いはず。

合わせて、メッセージも変更し、ユーザーのアクションを明示。
ただし、メッセージの中に停止キーワードを含めると、リマインダー自身が停止キーワードをコメントしてしまうので、HTMLエスケープすることで回避する。
